### PR TITLE
[FIX] 고교생, 대학생 마이페이지 활동 조회 시 활동유형/학기 state 비동기 처리 이슈 대응

### DIFF
--- a/sgb_web/src/pages/components/MyPageInfo.jsx
+++ b/sgb_web/src/pages/components/MyPageInfo.jsx
@@ -42,20 +42,21 @@ function MyPageInfo() {
   let sortQuery = activitySort;
   const handleSemester = (event) => {
     setSemester(event.target.value);
-    getUserInfo(sortQuery, semesterQuery);
+    // getUserInfo(sortQuery, semesterQuery);
   };
 
   const handleActivitySort = (sort) => {
     setActivitySort(sort);
-    getUserInfo(sortQuery, semesterQuery);
+    // getUserInfo(sortQuery, semesterQuery);
   };
 
-  const getUserInfo = (sortQuery, semesterQuery) => {
-    console.log("semesterQuery in getUserInfo: ", semesterQuery);
-    console.log("sortQuery in getUserInfo: ", sortQuery);
+  const getUserInfo = (activitySort, semester) => {
+    console.log("activitySort in getUserInfo: ", activitySort);
+    console.log("semester in getUserInfo: ", semester);
+
     axios
       .get(
-        `http://3.37.215.18:3000/mypage?sort=${sortQuery}&semester=${semesterQuery}`,
+        `http://3.37.215.18:3000/mypage?sort=${activitySort}&semester=${semester}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -144,8 +145,8 @@ function MyPageInfo() {
       });
   };
   useEffect(() => {
-    getUserInfo(sortQuery, semesterQuery);
-  }, []);
+    getUserInfo(activitySort, semester);
+  }, [activitySort, semester]);
 
   // 모달창 닫기 버튼
   const closeBtnHandler = () => {
@@ -289,8 +290,8 @@ function MyPageInfo() {
       const activityType = activity[0].activityType;
       const thoughts = activity[0].thoughts;
       const role = activity[0].role;
-      
-      modal.innerText = " "
+
+      modal.innerText = " ";
 
       var titleDiv = document.createElement("div");
       titleDiv.id = "mypage_detail_title";
@@ -306,7 +307,7 @@ function MyPageInfo() {
 
       var sgbDiv = document.createElement("div");
       sgbDiv.id = "mypage_detail_sgb";
-      sgbDiv.innerHTML=`
+      sgbDiv.innerHTML = `
       실제 생활기록부 기재양식<br><hr>
       ${name}(${startDate} ~ ${endDate}) ${role}<br><hr>
       ${thoughts}<br>`;
@@ -341,8 +342,8 @@ function MyPageInfo() {
       copyButton.innerText = "복사";
       copyButton.addEventListener("click", function () {
         var sgbContent = document.getElementById("mypage_detail_sgb").innerHTML;
-        sgbContent = sgbContent.replace(/<br>/g, '\n');
-        sgbContent = sgbContent.replace(/<hr>/g, ' ');
+        sgbContent = sgbContent.replace(/<br>/g, "\n");
+        sgbContent = sgbContent.replace(/<hr>/g, " ");
         // 복사할 내용을 클립보드에 복사
         const tempTextarea = document.createElement("textarea");
         tempTextarea.value = sgbContent;
@@ -350,8 +351,10 @@ function MyPageInfo() {
         tempTextarea.select();
         document.execCommand("copy");
         document.body.removeChild(tempTextarea);
-      
-        alert("클립보드에 내용이 복사되었습니다. 원하는 곳에 붙여넣어 사용하세요.");
+
+        alert(
+          "클립보드에 내용이 복사되었습니다. 원하는 곳에 붙여넣어 사용하세요."
+        );
       });
     }
 
@@ -394,7 +397,7 @@ function MyPageInfo() {
 
       var sgbDiv = document.createElement("div");
       sgbDiv.id = "mypage_detail_sgb";
-      sgbDiv.innerHTML=`
+      sgbDiv.innerHTML = `
       실제 생활기록부 기재양식<br><hr>
       ${subjectName} ${mainActivity} (${startDate} ~ ${endDate}) 
       ${subjectFurtherStudy}<hr>`;
@@ -429,8 +432,8 @@ function MyPageInfo() {
       copyButton.innerText = "복사";
       copyButton.addEventListener("click", function () {
         var sgbContent = document.getElementById("mypage_detail_sgb").innerHTML;
-        sgbContent = sgbContent.replace(/<br>/g, '\n');
-        sgbContent = sgbContent.replace(/<hr>/g, ' ');
+        sgbContent = sgbContent.replace(/<br>/g, "\n");
+        sgbContent = sgbContent.replace(/<hr>/g, " ");
         // 복사할 내용을 클립보드에 복사
         const tempTextarea = document.createElement("textarea");
         tempTextarea.value = sgbContent;
@@ -438,8 +441,10 @@ function MyPageInfo() {
         tempTextarea.select();
         document.execCommand("copy");
         document.body.removeChild(tempTextarea);
-      
-        alert("클립보드에 내용이 복사되었습니다. 원하는 곳에 붙여넣어 사용하세요.");
+
+        alert(
+          "클립보드에 내용이 복사되었습니다. 원하는 곳에 붙여넣어 사용하세요."
+        );
       });
     }
 
@@ -492,13 +497,13 @@ function MyPageInfo() {
 
       var sgbDiv = document.createElement("div");
       sgbDiv.id = "mypage_detail_sgb";
-      sgbDiv.innerHTML=`
+      sgbDiv.innerHTML = `
       실제 생활기록부 기재양식<br><hr>
       ${name} / ${prize || " "} / ${date}<br><hr> 
       ${role}<br>
       ${thoughts || " "}`;
       parentDiv.appendChild(sgbDiv);
-      
+
       var imageDiv = document.createElement("div");
       imageDiv.style.maxWidth = "50px !important";
       imageDiv.id = "mypage_detail_image";
@@ -533,8 +538,8 @@ function MyPageInfo() {
       copyButton.innerText = "복사";
       copyButton.addEventListener("click", function () {
         var sgbContent = document.getElementById("mypage_detail_sgb").innerHTML;
-        sgbContent = sgbContent.replace(/<br>/g, '\n');
-        sgbContent = sgbContent.replace(/<hr>/g, ' ');
+        sgbContent = sgbContent.replace(/<br>/g, "\n");
+        sgbContent = sgbContent.replace(/<hr>/g, " ");
         // 복사할 내용을 클립보드에 복사
         const tempTextarea = document.createElement("textarea");
         tempTextarea.value = sgbContent;
@@ -542,8 +547,10 @@ function MyPageInfo() {
         tempTextarea.select();
         document.execCommand("copy");
         document.body.removeChild(tempTextarea);
-      
-        alert("클립보드에 내용이 복사되었습니다. 원하는 곳에 붙여넣어 사용하세요.");
+
+        alert(
+          "클립보드에 내용이 복사되었습니다. 원하는 곳에 붙여넣어 사용하세요."
+        );
       });
     }
 
@@ -589,7 +596,7 @@ function MyPageInfo() {
       var sgbDiv = document.createElement("div");
       sgbDiv.id = "mypage_detail_sgb";
       sgbDiv.style.maxWidth = "250px";
-      sgbDiv.innerHTML=`
+      sgbDiv.innerHTML = `
       <hr>
       ${thoughts}<br>
       <hr>
@@ -630,9 +637,9 @@ function MyPageInfo() {
       copyButton.innerText = "복사";
       copyButton.addEventListener("click", function () {
         var sgbContent = document.getElementById("mypage_detail_sgb").innerHTML;
-        sgbContent = sgbContent.replace(/<br>/g, '\n');
-        sgbContent = sgbContent.replace(/<hr>/g, ' ');
-        sgbContent = sgbContent.replace(/&nbsp;/g, ' ');
+        sgbContent = sgbContent.replace(/<br>/g, "\n");
+        sgbContent = sgbContent.replace(/<hr>/g, " ");
+        sgbContent = sgbContent.replace(/&nbsp;/g, " ");
         // 복사할 내용을 클립보드에 복사
         const tempTextarea = document.createElement("textarea");
         tempTextarea.value = sgbContent;
@@ -640,8 +647,10 @@ function MyPageInfo() {
         tempTextarea.select();
         document.execCommand("copy");
         document.body.removeChild(tempTextarea);
-      
-        alert("클립보드에 내용이 복사되었습니다. 원하는 곳에 붙여넣어 사용하세요.");
+
+        alert(
+          "클립보드에 내용이 복사되었습니다. 원하는 곳에 붙여넣어 사용하세요."
+        );
       });
     }
   }
@@ -650,7 +659,8 @@ function MyPageInfo() {
 
   const handleMenuClick = (menu) => {
     setActiveMenu(menu);
-    handleActivitySort(menu); // 메뉴를 클릭하면 해당 메뉴에 해당하는 활동을 가져오도록 변경
+    setActivitySort(menu);
+    // handleActivitySort(menu); // 메뉴를 클릭하면 해당 메뉴에 해당하는 활동을 가져오도록 변경
   };
 
   return (
@@ -681,7 +691,7 @@ function MyPageInfo() {
             <div className="semester">
               <select
                 className="semester_select"
-                onChange={(e) => handleSemester(e)}
+                onChange={(e) => setSemester(e.target.value)}
               >
                 <option value="all">all</option>
                 <option value="1-1">1-1</option>
@@ -698,7 +708,7 @@ function MyPageInfo() {
                 alt="all"
                 width="80"
                 height="40"
-                onClick={() => handleMenuClick("all")}
+                onClick={(e) => handleMenuClick("all")}
               />
 
               <img

--- a/sgb_web/src/pages/components/MyPageInfo.jsx
+++ b/sgb_web/src/pages/components/MyPageInfo.jsx
@@ -144,6 +144,8 @@ function MyPageInfo() {
         console.log(error);
       });
   };
+
+  // 활동유형, 학기 state값이 변경될 때마다 axios 통신을 다시하며 리렌더링
   useEffect(() => {
     getUserInfo(activitySort, semester);
   }, [activitySort, semester]);
@@ -708,7 +710,7 @@ function MyPageInfo() {
                 alt="all"
                 width="80"
                 height="40"
-                onClick={(e) => handleMenuClick("all")}
+                onClick={() => handleMenuClick("all")}
               />
 
               <img

--- a/sgb_web/src/pages/components/MyPageInfoMentor.jsx
+++ b/sgb_web/src/pages/components/MyPageInfoMentor.jsx
@@ -36,22 +36,22 @@ function MyPageInfo() {
   let sortQuery = activitySort;
   const handleSemester = (event) => {
     setSemester(event.target.value);
-    console.log("semester event.target: ", event.target);
-    console.log("semesterQuery: ", semesterQuery);
-    console.log("sortQuery: ", sortQuery);
-    getUserInfo(sortQuery, semesterQuery);
+    // console.log("semester event.target: ", event.target);
+    // console.log("semesterQuery: ", semesterQuery);
+    // console.log("sortQuery: ", sortQuery);
+    // getUserInfo(sortQuery, semesterQuery);
   };
 
   const handleActivitySort = (sort) => {
     setActivitySort(sort);
-    console.log("semesterQuery: ", semesterQuery);
-    console.log("sortQuery: ", sortQuery);
-    getUserInfo(sortQuery, semesterQuery);
+    // console.log("semesterQuery: ", semesterQuery);
+    // console.log("sortQuery: ", sortQuery);
+    // getUserInfo(sortQuery, semesterQuery);
   };
 
-  const getUserInfo = (sortQuery, semesterQuery) => {
-    console.log("semesterQuery in getUserInfo: ", semesterQuery);
-    console.log("sortQuery in getUserInfo: ", sortQuery);
+  const getUserInfo = (activitySort, semester) => {
+    console.log("activitySort in getUserInfo: ", activitySort);
+    console.log("semester in getUserInfo: ", semester);
     axios
       .get(
         `http://3.37.215.18:3000/mypage?sort=${sortQuery}&semester=${semesterQuery}`,
@@ -89,7 +89,7 @@ function MyPageInfo() {
         });
 
         // 전체 활동 통합, 배열 내 인덱스 번호에 따른 uniqId로 id key 부여
-        let allActivity = [...allCreativeActivity, ...allPrizeActivity ];
+        let allActivity = [...allCreativeActivity, ...allPrizeActivity];
 
         allActivity.map((item, index) => {
           let uniqId = parseInt(index);
@@ -124,9 +124,11 @@ function MyPageInfo() {
         console.log(error);
       });
   };
+
+  // 활동유형, 학기 state값이 변경될 때마다 axios 통신을 다시하며 리렌더링
   useEffect(() => {
-    getUserInfo(sortQuery, semesterQuery);
-  }, []);
+    getUserInfo(activitySort, semester);
+  }, [activitySort, semester]);
 
   function parentFunction(data, sort, id) {
     setBannerClicked(data);
@@ -236,7 +238,7 @@ function MyPageInfo() {
       const thoughts = activity[0].thoughts;
       const role = activity[0].role;
 
-      modal.innerText = " "
+      modal.innerText = " ";
 
       var titleDiv = document.createElement("div");
       titleDiv.id = "mypage_detail_title";
@@ -252,7 +254,7 @@ function MyPageInfo() {
 
       var sgbDiv = document.createElement("div");
       sgbDiv.id = "mypage_detail_sgb";
-      sgbDiv.innerHTML=`
+      sgbDiv.innerHTML = `
       실제 생활기록부 기재양식<br><hr>
       ${name}(${startDate} ~ ${endDate}) ${role}<br><hr>
       ${thoughts}<br>`;
@@ -287,8 +289,8 @@ function MyPageInfo() {
       copyButton.innerText = "복사";
       copyButton.addEventListener("click", function () {
         var sgbContent = document.getElementById("mypage_detail_sgb").innerHTML;
-        sgbContent = sgbContent.replace(/<br>/g, '\n');
-        sgbContent = sgbContent.replace(/<hr>/g, ' ');
+        sgbContent = sgbContent.replace(/<br>/g, "\n");
+        sgbContent = sgbContent.replace(/<hr>/g, " ");
         // 복사할 내용을 클립보드에 복사
         const tempTextarea = document.createElement("textarea");
         tempTextarea.value = sgbContent;
@@ -296,8 +298,10 @@ function MyPageInfo() {
         tempTextarea.select();
         document.execCommand("copy");
         document.body.removeChild(tempTextarea);
-      
-        alert("클립보드에 내용이 복사되었습니다. 원하는 곳에 붙여넣어 사용하세요.");
+
+        alert(
+          "클립보드에 내용이 복사되었습니다. 원하는 곳에 붙여넣어 사용하세요."
+        );
       });
     }
 
@@ -350,13 +354,13 @@ function MyPageInfo() {
 
       var sgbDiv = document.createElement("div");
       sgbDiv.id = "mypage_detail_sgb";
-      sgbDiv.innerHTML=`
+      sgbDiv.innerHTML = `
       실제 생활기록부 기재양식<br><hr>
       ${name} / ${prize || " "} / ${date}<br><hr> 
       ${role}<br>
       ${thoughts || " "}`;
       parentDiv.appendChild(sgbDiv);
-      
+
       var imageDiv = document.createElement("div");
       imageDiv.style.maxWidth = "50px !important";
       imageDiv.id = "mypage_detail_image";
@@ -391,8 +395,8 @@ function MyPageInfo() {
       copyButton.innerText = "복사";
       copyButton.addEventListener("click", function () {
         var sgbContent = document.getElementById("mypage_detail_sgb").innerHTML;
-        sgbContent = sgbContent.replace(/<br>/g, '\n');
-        sgbContent = sgbContent.replace(/<hr>/g, ' ');
+        sgbContent = sgbContent.replace(/<br>/g, "\n");
+        sgbContent = sgbContent.replace(/<hr>/g, " ");
         // 복사할 내용을 클립보드에 복사
         const tempTextarea = document.createElement("textarea");
         tempTextarea.value = sgbContent;
@@ -400,8 +404,10 @@ function MyPageInfo() {
         tempTextarea.select();
         document.execCommand("copy");
         document.body.removeChild(tempTextarea);
-      
-        alert("클립보드에 내용이 복사되었습니다. 원하는 곳에 붙여넣어 사용하세요.");
+
+        alert(
+          "클립보드에 내용이 복사되었습니다. 원하는 곳에 붙여넣어 사용하세요."
+        );
       });
     }
   }
@@ -441,7 +447,7 @@ function MyPageInfo() {
             <div className="semester">
               <select
                 className="semester_select"
-                onChange={(e) => handleSemester(e)}
+                onChange={(e) => setSemester(e.target.value)}
               >
                 <option value="all">all</option>
                 <option value="1-1">1-1</option>


### PR DESCRIPTION
### 이전의 이슈
- useState의 비동기 처리로 인해, 활동 유형별 메뉴 버튼을 더블클릭해야 유형에 맞는 활동이 조회되고, 학기 토글을 1-1을 눌렀다가 -> 1-2를 눌렀다가 -> 2-1을 누른다고 한다면, 한 단계씩 늦게 처리되어 1-2를 누를 시점에 1-1학기 조회 결과가 출력되고 2-1를 누를 시점에 1-2학기 조회 결과가 출력되는 문제가 있었습니다.
- **문제의 원인은! 페이지에 처음 렌더링될 때에만 getUserInfo 함수가 시행되도록` useEffect 구문 내부의 [ ] 배열 인자를 빈 칸으로 놔둔 것`이 가장 컸습니다!** 

### 수정사항
1. 학기 토글의 select 태그에 onChange={setSemester(e.target.value)}를 추가하여 클릭한 토글이 변경될 때마다 semester state값이 바로 바뀌도록 수정하였습니다. 
2. activitySort와 semester라는 state를 `sortQuery`, `semesterQuery`라는 새로운 `let` 변수에 굳이 담은 뒤에, getUserInfo에서 api url에  그 두 `let` 변수를 넣어주지 않고 state 값을 바로 넣어주었습니다.
3. getUserInfo (마이페이지 활동 조회 api와 통신) 함수가 useEffect 구문을 통해 activitySort(활동유형), semester(학기) state 값이 변화할 때마다 리렌더링 되도록 수정하였습니다. (배열 인자에 두 개의 state 값을 넣어줌!)
=> 결과적으로 활동유형 메뉴 버튼과 학기 토글을 새로 누를 때마다 화면상에 검색 쿼리에 맞는 결과가 정상적으로 출력됩니다.