### PR TITLE
[FIX] 랜딩페이지 접속 시 기존 로그인 쿠키 삭제

### DIFF
--- a/sgb_web/src/pages/LandingPage.jsx
+++ b/sgb_web/src/pages/LandingPage.jsx
@@ -3,11 +3,13 @@ import "./LandingPage.css";
 import landing_student from "./components/img/landing_student.png";
 import landing_mentor from "./components/img/landing_mentor.png";
 import { Link } from "react-router-dom";
-import { getCookie, setCookie } from "../lib/cookie";
+import { getCookie, setCookie, removeCookie } from "../lib/cookie";
 
 const LandingPage = () => {
   const userId = getCookie("userId");
   const token = getCookie("accessToken");
+  removeCookie("userId");
+  removeCookie("accessToken");
 
   // 미로그인 시 이미지 클릭 - 미로그인 홈으로 이동
   if (!userId || !token) {
@@ -23,8 +25,7 @@ const LandingPage = () => {
                 alt="student"
                 width="400"
                 height="100"
-              />
-              {" "}
+              />{" "}
             </Link>
             <Link to="/mentorHome">
               <img src={landing_mentor} alt="mentor" width="400" height="100" />
@@ -48,8 +49,7 @@ const LandingPage = () => {
                 alt="student"
                 width="400"
                 height="100"
-              />
-            {" "}
+              />{" "}
             </Link>
             <Link to="/loginedMentorHome">
               <img src={landing_mentor} alt="mentor" width="400" height="100" />


### PR DESCRIPTION
### 수정사항
- 고등학생 홈 / 대학생 홈 접속 후 로그인을 한 뒤, 랜딩페이지 `~/` 접속 시 기존 로그인정보가 삭제되도록 수정합니다. 

### 관련 이슈
- #142 