### PR TITLE
[FIX] 랜딩페이지 접속 시 쿠키 삭제 코드 복구, 랜딩페이지 회원별 버튼 클릭시 로그인 화면 이동

### DIFF
--- a/sgb_web/src/pages/LandingPage.jsx
+++ b/sgb_web/src/pages/LandingPage.jsx
@@ -8,8 +8,6 @@ import { getCookie, setCookie, removeCookie } from "../lib/cookie";
 const LandingPage = () => {
   const userId = getCookie("userId");
   const token = getCookie("accessToken");
-  removeCookie("userId");
-  removeCookie("accessToken");
 
   // 미로그인 시 이미지 클릭 - 미로그인 홈으로 이동
   if (!userId || !token) {

--- a/sgb_web/src/pages/LandingPage.jsx
+++ b/sgb_web/src/pages/LandingPage.jsx
@@ -17,7 +17,7 @@ const LandingPage = () => {
           <h3 className="landing-light">너의 길을 오롯이 응원해,</h3>
           <h1 className="landing-bold">생기부 인사이드</h1>
           <div className="landing-btn">
-            <Link to="/home">
+            <Link to="/login">
               <img
                 src={landing_student}
                 alt="student"
@@ -25,7 +25,7 @@ const LandingPage = () => {
                 height="100"
               />{" "}
             </Link>
-            <Link to="/mentorHome">
+            <Link to="/mentorLogin">
               <img src={landing_mentor} alt="mentor" width="400" height="100" />
             </Link>
           </div>

--- a/sgb_web/src/pages/components/Hello.jsx
+++ b/sgb_web/src/pages/components/Hello.jsx
@@ -14,7 +14,7 @@ const Hello = () => {
 
   if (!userId || !token) {
     console.log("cannnot get userId or token from cookie");
-    // return;
+    return;
   } else {
     console.log("userId or token found");
   }

--- a/sgb_web/src/pages/components/MentorHello.jsx
+++ b/sgb_web/src/pages/components/MentorHello.jsx
@@ -14,7 +14,7 @@ const MentorHello = () => {
 
   if (!userId || !token) {
     console.log("cannnot get userId or token from cookie");
-    // return;
+    return;
   } else {
     console.log("userId or token found");
   }


### PR DESCRIPTION
### 수정사항
- 랜딩 페이지 접속 시 쿠키 삭제는 정상적으로 되지만, 로그인을 했다가 랜딩페이지로 돌아가 쿠키를 지우고, 대학생/고등학생 홈에 접속할 경우 로그인/회원가입 버튼이 보이지 않는 문제가 발생해 코드를 복원했습니다.
- 이후 차선책으로 랜딩페이지 고등학생/대학생 버튼을 클릭하면 각 회원 유형에 맞는 로그인 화면으로 이동하도록 수정했습니다.